### PR TITLE
build: using musl to compile n00b

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ RUN apt-get update && apt-get install -y \
     curl \
     gcc-14 \
     make \
+    musl-tools \
     ninja-build \
     pipx \
     wget

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,8 @@
+ARG BASE=alpine
+
+# ----------------------------------------------------------------------------
+
+# alpine edge has recent meson version
 FROM alpine:edge AS alpine
 
 RUN apk add --no-cache \
@@ -6,20 +11,21 @@ RUN apk add --no-cache \
     gcc \
     git \
     linux-headers \
-    gcompat \
     make \
     meson \
+    musl-dev \
     ncurses \
     perl \
     wget
-    # musl-dev
+
+# add musl-gcc so its consistent CC with ubuntu
+RUN ln -s $(which gcc) /usr/bin/musl-gcc
 
 # ----------------------------------------------------------------------------
 
 FROM ubuntu:24.04 AS ubuntu
 
 ENV PATH=/root/.local/bin:$PATH
-ENV CC=gcc-14
 
 RUN apt-get update && apt-get install -y \
     build-essential \
@@ -31,4 +37,11 @@ RUN apt-get update && apt-get install -y \
     pipx \
     wget
 
+# get latest meson via pipx as apt has ancient version
 RUN pipx install meson
+
+# ----------------------------------------------------------------------------
+
+FROM $BASE
+
+ENV CC=musl-gcc

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,11 @@
 services:
   n00b:
-    build: .
+    build:
+      context: .
+      args:
+        BASE: ${BASE:-alpine}
     working_dir: $PWD
     volumes:
       - .:$PWD
+    environment:
+      CC: ${CC:-musl-gcc}

--- a/include/hatrack/base.h
+++ b/include/hatrack/base.h
@@ -30,6 +30,7 @@
 #include <stdbool.h>
 #include <stdalign.h>
 #include <stdatomic.h>
+#include <sys/types.h>
 
 // IWYU program: end_exports
 

--- a/meson.build
+++ b/meson.build
@@ -339,7 +339,12 @@ libmath_dep = cc.find_library('m', required : false)
 libthreads_dep = dependency('threads', required : true)
 
 # https://stackoverflow.com/questions/73053163/how-to-force-meson-to-use-only-wrap-subproject
-libbacktrace = subproject('libbacktrace').get_variable('libbacktrace_dep')
+if (host_machine.system() == 'darwin')
+  linuxheaders_dep = declare_dependency()
+else
+  linuxheaders_dep = subproject('linuxheaders').get_variable('linuxheaders_dep')
+endif
+libbacktrace_dep = subproject('libbacktrace').get_variable('libbacktrace_dep')
 libffi_dep = subproject('libffi').get_variable('libffi_dep')
 libunibreak_dep = subproject('libunibreak').get_variable('libunibreak_dep')
 libutf8proc_dep = subproject('libutf8proc').get_variable('utf8proc_dep')
@@ -352,13 +357,14 @@ if get_option('show_preprocessor_config').enabled()
 endif
 
 deps = [
-  libbacktrace,
+  libbacktrace_dep,
   libcurl_dep,
   libffi_dep,
   libmath_dep,
   libthreads_dep,
   libunibreak_dep,
   libutf8proc_dep,
+  linuxheaders_dep,
   openssl_dep,
 ]
 link_with = [

--- a/src/core/init.c
+++ b/src/core/init.c
@@ -323,6 +323,12 @@ extern void n00b_crash_init();
 __attribute__((constructor)) void
 n00b_init(int argc, char **argv, char **envp)
 {
+    // musl does not pass argv to attribute constructors
+    // https://www.openwall.com/lists/musl/2020/07/15/1
+    if (argv == NULL) {
+        return;
+    }
+
     static int inited = false;
 
     if (!inited) {

--- a/subprojects/linuxheaders.wrap
+++ b/subprojects/linuxheaders.wrap
@@ -1,0 +1,9 @@
+[wrap-file]
+directory = kernel-headers-4.19.88
+source_url = https://github.com/sabotage-linux/kernel-headers/archive/v4.19.88.tar.gz
+source_filename = v4.19.88.tar.gz
+source_hash = d104397fc657ffb0f0bda46f54fd182b76a9ebc324149c183a4ff8c86a8db53d
+patch_directory = linuxheaders
+
+[provide]
+linuxheaders = linuxheaders_dep

--- a/subprojects/packagefiles/libcurl/meson.build
+++ b/subprojects/packagefiles/libcurl/meson.build
@@ -16,10 +16,9 @@ i = run_command(
   '''
 [ -n "$(find -name libcurl.a)" ] && exit 0
 export CPPFLAGS="-I$(realpath ../openssl-*)/include $CPPFLAGS"
-if [ "$(uname)" = "Darwin" ] ; then
 export LDFLAGS="-L$(realpath ../openssl-*) $LDFLAGS"
-else
-export LDFLAGS="-static -L$(realpath ../openssl-*) $LDFLAGS"
+if [ "$(uname)" != "Darwin" ] ; then
+export LDFLAGS="-static $LDFLAGS"
 fi
 ./configure -v \
   --with-openssl=$(realpath ../openssl-*) \

--- a/subprojects/packagefiles/libffi/meson.build
+++ b/subprojects/packagefiles/libffi/meson.build
@@ -9,11 +9,20 @@ project(
   meson_version : '>=1.5.0',
 )
 
+if (host_machine.system() == 'darwin')
+  linuxheaders_dep = declare_dependency()
+else
+  linuxheaders_dep = dependency('linuxheaders')
+endif
+
 i = run_command(
   'sh',
   '-exc',
   '''
 [ -n "$(find -name libffi.a)" ] && exit 0
+if [ "$(uname)" != "Darwin" ] ; then
+export CPPFLAGS="-I$(realpath ../kernel-headers-*)/include $CPPFLAGS"
+fi
 ./configure \
   --disable-docs
 make
@@ -38,6 +47,9 @@ dirname $(find $PWD -name libffi.a)
 message(libs)
 
 libffi_dep = declare_dependency(
+  dependencies : [
+    linuxheaders_dep,
+  ],
   include_directories : [
     include_directories('.'),
   ],

--- a/subprojects/packagefiles/linuxheaders/meson.build
+++ b/subprojects/packagefiles/linuxheaders/meson.build
@@ -1,0 +1,29 @@
+project(
+  'linuxheaders',
+  'c',
+  version : '4.19.88',
+  default_options: [],
+  meson_version : '>=1.5.0',
+)
+
+i = run_command(
+  'sh',
+  '-exc',
+  '''
+[ -d include ] && exit 0
+make ARCH=$(uname -m) prefix= DESTDIR=. install
+  ''',
+  capture : true,
+  check : true,
+)
+message(i.stdout())
+message(i.stderr())
+
+linuxheaders_dep = declare_dependency(
+  include_directories : [
+    include_directories('include'),
+  ],
+)
+
+# needs override as its external project
+meson.override_dependency('linuxheaders', linuxheaders_dep)

--- a/subprojects/packagefiles/openssl/meson.build
+++ b/subprojects/packagefiles/openssl/meson.build
@@ -5,18 +5,24 @@ project(
   meson_version : '>=1.5.0',
 )
 
+if (host_machine.system() == 'darwin')
+  linuxheaders_dep = declare_dependency()
+else
+  linuxheaders_dep = dependency('linuxheaders')
+endif
+
 i = run_command(
   'sh',
   '-exc',
   '''
 [ -n "$(find -name libcrypto.a)" ] && exit 0
+if [ "$(uname)" != "Darwin" ] ; then
+export N00B_STATIC=-static
+export CPPFLAGS="-I$(realpath ../kernel-headers-*)/include $CPPFLAGS"
+fi
 # cannot disable deprecated/engine as curl uses these
 # -no-deprecated
 # -no-engine
-if [ "$(uname)" != "Darwin" ] ; then
-export N00B_STATIC=-static
-fi
-
 ./config \
   enable-ec_nistp_64_gcc_128 \
   no-afalgeng \
@@ -60,6 +66,9 @@ message(i.stdout())
 message(i.stderr())
 
 openssl_dep = declare_dependency(
+  dependencies : [
+    linuxheaders_dep,
+  ],
   include_directories : [
     include_directories('./include/openssl'),
   ],


### PR DESCRIPTION
it needs to explicitly opted-in via:

```sh
export CC=musl-gcc
```

eventually we should prolly add a meson flag so we can toggle between gcc and musl