### PR TITLE
exporting n00b_duration_repr in n00b.h

### DIFF
--- a/include/adts/duration.h
+++ b/include/adts/duration.h
@@ -8,6 +8,7 @@ extern n00b_duration_t *n00b_thread_cpu(void);
 extern n00b_duration_t *n00b_uptime(void);
 extern n00b_duration_t *n00b_program_clock(void);
 extern void             n00b_init_program_timestamp(void);
+extern n00b_string_t   *n00b_duration_repr(n00b_duration_t *);
 extern n00b_duration_t *n00b_duration_diff(n00b_duration_t *,
                                            n00b_duration_t *);
 extern n00b_duration_t *n00b_duration_add(n00b_duration_t *,

--- a/src/adts/duration.c
+++ b/src/adts/duration.c
@@ -471,8 +471,8 @@ repr_ns(int64_t n)
     return n00b_string_join(parts, n00b_cached_comma_padded());
 }
 
-static n00b_string_t *
-duration_repr(n00b_duration_t *ts)
+n00b_string_t *
+n00b_duration_repr(n00b_duration_t *ts)
 {
     // TODO: Do better.
 
@@ -583,7 +583,7 @@ duration_lit(n00b_string_t        *s,
 const n00b_vtable_t n00b_duration_vtable = {
     .methods = {
         [N00B_BI_CONSTRUCTOR]  = (n00b_vtable_entry)duration_init,
-        [N00B_BI_REPR]         = (n00b_vtable_entry)duration_repr,
+        [N00B_BI_REPR]         = (n00b_vtable_entry)n00b_duration_repr,
         [N00B_BI_FROM_LITERAL] = (n00b_vtable_entry)duration_lit,
         [N00B_BI_EQ]           = (n00b_vtable_entry)n00b_duration_eq,
         [N00B_BI_LT]           = (n00b_vtable_entry)n00b_duration_lt,


### PR DESCRIPTION
this is useful for debugging as it allows to print repr of the duration object externally such as from nim wrapping