### PR TITLE
Bloom filters

### DIFF
--- a/include/adts/bloom.h
+++ b/include/adts/bloom.h
@@ -1,0 +1,20 @@
+#pragma once
+#include "n00b.h"
+
+typedef hatrack_bloom_t n00b_bloom_t;
+
+// This should move to its own module, and allow for custom hash functions.
+
+static inline void
+n00b_bloom_add(hatrack_bloom_t *bf, void *obj)
+{
+    hatrack_hash_t hv = n00b_hash(obj);
+    hatrack_bloom_add(bf, &hv);
+}
+
+static inline bool
+n00b_bloom_contains(hatrack_bloom_t *bf, void *obj)
+{
+    hatrack_hash_t hv = n00b_hash(obj);
+    return hatrack_bloom_contains(bf, &hv);
+}

--- a/include/adts/dict.h
+++ b/include/adts/dict.h
@@ -2,7 +2,8 @@
 
 #include "n00b.h"
 
-#define n00b_dict(x, y) n00b_new(n00b_type_dict(x, y))
+#define n00b_dict(x, y)                n00b_new(n00b_type_dict(x, y))
+#define n00b_dict_with_filter(x, y, d) n00b_new(n00b_type_dict(x, y), 1ULL, d)
 extern n00b_dict_t *n00b_dict_copy(n00b_dict_t *);
 extern n00b_list_t *n00b_dict_keys(n00b_dict_t *);
 extern n00b_list_t *n00b_dict_values(n00b_dict_t *);

--- a/include/core/dt_objects.h
+++ b/include/core/dt_objects.h
@@ -164,6 +164,7 @@ typedef enum : int64_t {
     N00B_T_SESSION,
     N00B_T_SESSION_STATE,
     N00B_T_SESSION_TRIGGER,
+    N00B_T_BLOOM,
     N00B_NUM_BUILTIN_DTS,
 } n00b_builtin_t;
 

--- a/include/core/hash.h
+++ b/include/core/hash.h
@@ -1,0 +1,5 @@
+#pragma once
+#include "n00b.h"
+
+extern hatrack_hash_t n00b_custom_string_hash(void *);
+extern hatrack_hash_t n00b_hash(void *);

--- a/include/core/object.h
+++ b/include/core/object.h
@@ -231,4 +231,5 @@ extern const n00b_vtable_t n00b_regex_vtable;
 extern const n00b_vtable_t n00b_session_vtable;
 extern const n00b_vtable_t n00b_session_state_vtable;
 extern const n00b_vtable_t n00b_session_trigger_vtable;
+extern const n00b_vtable_t n00b_bloom_vtable;
 #endif

--- a/include/core/type.h
+++ b/include/core/type.h
@@ -751,6 +751,12 @@ n00b_type_session_trigger(void)
 }
 
 static inline n00b_type_t *
+n00b_type_bloom_filter(void)
+{
+    return n00b_bi_types[N00B_T_BLOOM];
+}
+
+static inline n00b_type_t *
 n00b_merge_types(n00b_type_t *t1, n00b_type_t *t2, int *warning)
 {
     n00b_type_t *result = n00b_unify(t1, t2);
@@ -1054,6 +1060,16 @@ n00b_type_is_session_trigger(n00b_type_t *t)
     }
     t = n00b_type_resolve(t);
     return t->typeid == N00B_T_SESSION_TRIGGER;
+}
+
+static inline bool
+n00b_type_is_bloom_filter(n00b_type_t *t)
+{
+    if (!n00b_ensure_type(t)) {
+        return false;
+    }
+    t = n00b_type_resolve(t);
+    return t->typeid == N00B_T_BLOOM;
 }
 
 static inline bool

--- a/include/hatrack/bloom.h
+++ b/include/hatrack/bloom.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2025 Crash Override, Inc.
+ *
+ *  Name:           bloom.c
+ *  Description:    High performance, lock-free bloom filter
+ *
+ *  Author:         John Viega, john@crashoverride.com
+ */
+
+#pragma once
+#include "hatrack_common.h"
+#include "hatomic.h"
+
+typedef struct {
+    _Atomic(uint64_t) *bitfield;
+    unsigned int       bit_length;
+    unsigned int       hash_width;
+    unsigned int       num_hashes;
+    unsigned int       hash_bytes;
+    double             false_rate;
+} hatrack_bloom_t;
+
+HATRACK_EXTERN void hatrack_bloom_init(hatrack_bloom_t *,
+                                       double,
+                                       unsigned int,
+                                       int);
+HATRACK_EXTERN void hatrack_bloom_add(hatrack_bloom_t *, hatrack_hash_t *);
+HATRACK_EXTERN bool hatrack_bloom_contains(hatrack_bloom_t *, hatrack_hash_t *);

--- a/include/hatrack/hash.h
+++ b/include/hatrack/hash.h
@@ -40,6 +40,11 @@ typedef union {
     XXH128_hash_t  xhv;
 } hash_internal_conversion_t;
 
+typedef struct {
+    int32_t hash_offset;
+    int32_t cache_offset;
+} hatrack_offset_info_t;
+
 static inline hatrack_hash_t
 hash_cstr(char *key)
 {
@@ -79,3 +84,9 @@ hash_pointer(void *key)
 
     return u.lhv;
 }
+
+HATRACK_EXTERN hatrack_hash_t
+hatrack_hash_by_type(uint32_t,
+                     hatrack_hash_func_t,
+                     hatrack_offset_info_t *,
+                     void *);

--- a/include/hatrack/hatrack_common.h
+++ b/include/hatrack/hatrack_common.h
@@ -174,6 +174,26 @@ hatrack_round_up_to_power_of_2(uint64_t n)
     return 0x8000000000000000ull >> (__builtin_clzll(n) - 1);
 }
 
+static inline uint64_t
+hatrack_round_up_to_given_power_of_2(uint64_t power, uint64_t n)
+{
+    uint64_t modulus   = (power - 1);
+    uint64_t remainder = n & modulus;
+
+    if (!remainder) {
+        return n;
+    }
+    else {
+        return (n & ~modulus) + power;
+    }
+}
+
+static inline uint64_t
+hatrack_int_log2(uint64_t n)
+{
+    return 63 - __builtin_clzll(n);
+}
+
 typedef void (*hatrack_panic_func)(void *arg, const char *msg);
 
 [[noreturn]] HATRACK_EXTERN void

--- a/include/n00b.h
+++ b/include/n00b.h
@@ -28,6 +28,7 @@ typedef struct n00b_string_t n00b_string_t;
 
 // Core object.
 #include "core/object.h"
+#include "core/hash.h"
 
 #include "text/color.h"
 #include "adts/list.h"
@@ -56,6 +57,7 @@ typedef struct n00b_string_t n00b_string_t;
 #include "core/exception.h"
 
 // Other data types.
+#include "adts/bloom.h"
 #include "adts/dict.h"
 #include "adts/set.h"
 #include "adts/net_addr.h"

--- a/meson.build
+++ b/meson.build
@@ -209,7 +209,8 @@ n00b_core = [
     'src/core/thread.c',        # Basic thread interface
     'src/core/thread_tsi.c',    # Internal API; thread specific data
     'src/core/thread_coop.c',   # Mainly internal API for stop-the-world support
-    'src/core/lock.c',     
+    'src/core/lock.c',
+    'src/core/hash.c',
 ]
 
 n00b_runtime = [
@@ -256,6 +257,7 @@ n00b_adts = [
     'src/adts/flags.c',
     'src/adts/box.c',
     'src/adts/bytering.c',
+    'src/adts/bloom.c',
 ]
 
 n00b_io = [
@@ -357,6 +359,8 @@ hat_primary = [
     'src/hatrack/support/mmm.c',
     'src/hatrack/support/counters.c',
     'src/hatrack/support/malloc.c',
+    'src/hatrack/filter/bloom.c',
+    'src/hatrack/hash/hash.c',    
     'src/hatrack/hash/crown.c',
     'src/hatrack/hash/dict.c',
     'src/hatrack/hash/xxhash.c',

--- a/src/adts/bloom.c
+++ b/src/adts/bloom.c
@@ -1,0 +1,30 @@
+#include "n00b.h"
+
+void
+n00b_bloom_init(n00b_bloom_t *bf, va_list args)
+{
+    double   false_pct      = 0.01;
+    uint32_t expected_items = 250000;
+    int      num_hashes     = -1; // Compute it.
+
+    n00b_karg_va_init(args);
+    n00b_kw_float("false_pct", false_pct);
+    n00b_kw_uint32("set_size", expected_items);
+    n00b_kw_int32("num_hashes", num_hashes);
+
+    if (false_pct <= 0.0 || false_pct >= 1) {
+        N00B_CRAISE("Invalid value for false_pct");
+    }
+
+    if (expected_items < 10) {
+        expected_items = 10;
+    }
+
+    hatrack_bloom_init(bf, false_pct, expected_items, num_hashes);
+}
+
+const n00b_vtable_t n00b_bloom_vtable = {
+    .methods = {
+        [N00B_BI_CONSTRUCTOR] = (n00b_vtable_entry)n00b_bloom_init,
+    },
+};

--- a/src/core/hash.c
+++ b/src/core/hash.c
@@ -1,0 +1,124 @@
+#include "n00b.h"
+
+#ifndef NO___INT128_T
+
+static inline bool
+hatrack_bucket_unreserved(hatrack_hash_t hv)
+{
+    return !hv;
+}
+
+#else
+static inline bool
+hatrack_bucket_unreserved(hatrack_hash_t hv)
+{
+    return !hv.w1 && !hv.w2;
+}
+
+#endif
+
+// The n00b object hash.
+
+hatrack_hash_t
+n00b_hash(void *object)
+{
+    if (!n00b_in_heap(object)) {
+        return hash_pointer(object);
+    }
+
+    n00b_type_t *t = n00b_get_my_type(object);
+
+    if (!t) {
+        return hash_pointer(object);
+    }
+
+    n00b_dt_info_t       *info      = n00b_type_get_data_type_info(t);
+    size_t                hash_type = info->hash_fn;
+    hatrack_hash_func_t   func      = NULL;
+    hatrack_offset_info_t offsets   = {0, 0};
+
+    switch (hash_type) {
+    case HATRACK_DICT_KEY_TYPE_OBJ_CUSTOM:
+        func = n00b_custom_string_hash;
+        break;
+    case HATRACK_DICT_KEY_TYPE_OBJ_CSTR:
+        offsets.hash_offset = N00B_string_HASH_KEY_POINTER_OFFSET;
+        break;
+    case HATRACK_DICT_KEY_TYPE_OBJ_PTR:
+    case HATRACK_DICT_KEY_TYPE_OBJ_INT:
+    case HATRACK_DICT_KEY_TYPE_OBJ_REAL:
+        offsets.cache_offset = N00B_HASH_CACHE_OBJ_OFFSET;
+        break;
+    }
+
+    return hatrack_hash_by_type(hash_type, func, &offsets, object);
+}
+
+static inline hatrack_hash_t
+new_string_hash(n00b_string_t *s)
+{
+    union {
+        hatrack_hash_t local_hv;
+        XXH128_hash_t  xxh_hv;
+    } hv;
+
+    if (!s || !s->codepoints) {
+        s = n00b_cached_empty_string();
+    }
+
+    hatrack_hash_t *cache = (void *)(((char *)s) + N00B_HASH_CACHE_OBJ_OFFSET);
+    hv.local_hv           = *cache;
+
+    // This isn't really testing a bucket, just seeing if the hash
+    // value is 0.
+    if (hatrack_bucket_unreserved(hv.local_hv)) {
+        hv.xxh_hv = XXH3_128bits(s->data, s->u8_bytes);
+        *cache    = hv.local_hv;
+    }
+
+    return *cache;
+}
+
+static inline hatrack_hash_t
+old_string_hash(n00b_string_t *s)
+{
+    union {
+        hatrack_hash_t local_hv;
+        XXH128_hash_t  xxh_hv;
+    } hv;
+
+    static n00b_string_t *n00b_null_string = NULL;
+
+    if (n00b_null_string == NULL) {
+        n00b_null_string = n00b_cached_empty_string();
+        n00b_gc_register_root(&n00b_null_string, 1);
+    }
+
+    hatrack_hash_t *cache = (void *)(((char *)s) + N00B_HASH_CACHE_OBJ_OFFSET);
+
+    hv.local_hv = *cache;
+
+    if (!n00b_string_codepoint_len(s)) {
+        s = n00b_null_string;
+    }
+
+    if (hatrack_bucket_unreserved(hv.local_hv)) {
+        hv.xxh_hv = XXH3_128bits(s->data, s->u8_bytes);
+
+        *cache = hv.local_hv;
+    }
+
+    return *cache;
+}
+
+hatrack_hash_t
+n00b_custom_string_hash(void *v)
+{
+    n00b_type_t *t = n00b_get_my_type(v);
+
+    if (t->base_index == N00B_T_STRING) {
+        return new_string_hash(v);
+    }
+
+    return old_string_hash(v);
+}

--- a/src/core/object.c
+++ b/src/core/object.c
@@ -706,6 +706,15 @@ const n00b_dt_info_t n00b_base_type_info[N00B_NUM_BUILTIN_DTS] = {
         .hash_fn   = HATRACK_DICT_KEY_TYPE_OBJ_PTR,
         .mutable   = false,
     },
+    [N00B_T_BLOOM] = {
+        .name      = "Bloom_filter",
+        .typeid    = N00B_T_BLOOM,
+        .alloc_len = sizeof(n00b_bloom_t),
+        .vtable    = &n00b_bloom_vtable,
+        .dt_kind   = N00B_DT_KIND_primitive,
+        .hash_fn   = HATRACK_DICT_KEY_TYPE_OBJ_PTR,
+        .mutable   = false,
+    },
 
 };
 

--- a/src/hatrack/filter/bloom.c
+++ b/src/hatrack/filter/bloom.c
@@ -1,0 +1,139 @@
+/*
+ * Copyright © 2025 Crash Override, Inc.
+ *
+ *  Name:           bloom.c
+ *  Description:    High performance, lock-free bloom filter
+ *
+ *  Author:         John Viega, john@crashoverride.com
+ */
+
+#include "hatrack/bloom.h"
+#include "hatrack/hash.h"
+#include "hatrack/dict.h"
+#include "hatrack/hatomic.h"
+#include <math.h>
+
+#define HATRACK_BLOOM_HASHSIZE (sizeof(hatrack_hash_t) * 8)
+#define HATRACK_LOG2           0.6931471805599453
+#define HATRACK_LOG2_SQ        0.4804530139182014
+
+void
+hatrack_bloom_init(hatrack_bloom_t *bf,
+                   double           false_pct,
+                   unsigned int     expected_items,
+                   int              num_hashes)
+{
+    double  nfplog = -log(false_pct);
+    double  optlen = expected_items * nfplog / HATRACK_LOG2_SQ;
+    int64_t bitlen = (int64_t)(optlen + .5);
+
+    if (num_hashes <= 0) {
+        double opthash = nfplog / HATRACK_LOG2;
+        opthash += .5;
+        num_hashes = (int)opthash;
+    }
+
+    // We round up to a multiple of 8 bits to make sure the array
+    // divides cleanly into bytes.
+    bf->bit_length       = hatrack_round_up_to_given_power_of_2(bitlen, 8);
+    bf->hash_width       = hatrack_int_log2(bf->bit_length);
+    bf->num_hashes       = num_hashes;
+    int aligned_bytes_ph = hatrack_round_up_to_power_of_2(bf->hash_width) >> 3;
+    bf->hash_bytes       = aligned_bytes_ph * num_hashes;
+    bf->bitfield         = hatrack_malloc(bf->bit_length / 8);
+}
+
+static inline char *
+bloom_get_stream(hatrack_bloom_t *bf, hatrack_hash_t *hv, char *arr)
+{
+    XXH128_hash_t expanded;
+
+    if (bf->hash_bytes <= sizeof(hatrack_hash_t)) {
+        return (char *)hv;
+    }
+
+    char        *p      = arr;
+    uint64_t    *hv64   = (uint64_t *)hv;
+    uint64_t     ctr[4] = {0, hv64[0], hv64[1], 0};
+    unsigned int len    = bf->hash_bytes;
+
+    while (len >= sizeof(hatrack_hash_t)) {
+        expanded = XXH3_128bits(&ctr[0], sizeof(ctr));
+        memcpy(p, &expanded, sizeof(hatrack_hash_t));
+        p += sizeof(hatrack_hash_t);
+        len -= sizeof(hatrack_hash_t);
+        ctr[0]++;
+        ctr[3]++;
+    }
+    if (len) {
+        expanded = XXH3_128bits(&ctr[0], sizeof(ctr));
+        memcpy(p, &expanded, len);
+    }
+
+    return arr;
+}
+
+static inline uint64_t
+bloom_hash_value(char *stream, unsigned int width)
+{
+    uint64_t result = 0;
+
+    assert(width <= sizeof(int64_t));
+
+    for (unsigned int i = 0; i < width; i++) {
+        result <<= 8;
+        result |= (uint64_t)(*(uint8_t *)stream++);
+    }
+
+    return result;
+}
+
+void
+hatrack_bloom_add(hatrack_bloom_t *bf, hatrack_hash_t *hv)
+{
+    unsigned int width = bf->hash_width;
+    char         arr[bf->hash_bytes];
+    char        *hash_stream = bloom_get_stream(bf, hv, arr);
+    uint64_t     one_hash;
+
+    for (unsigned int i = 0; i < bf->num_hashes; i++) {
+        one_hash = bloom_hash_value(hash_stream, width);
+        hash_stream += width;
+
+        uint64_t           word_number = one_hash >> 6;
+        uint64_t           bit_index   = one_hash & 63;
+        uint64_t           one_bit     = 1 << bit_index;
+        _Atomic(uint64_t) *p           = bf->bitfield + word_number;
+        uint64_t           expected    = atomic_read(p);
+        uint64_t           desired;
+
+        do {
+            desired = expected | one_bit;
+        } while (!CAS(p, &expected, desired));
+    }
+}
+
+bool
+hatrack_bloom_contains(hatrack_bloom_t *bf, hatrack_hash_t *hv)
+{
+    unsigned int width = bf->hash_width;
+    char         arr[bf->hash_bytes];
+    char        *hash_stream = bloom_get_stream(bf, hv, arr);
+    uint64_t     one_hash;
+
+    for (unsigned int i = 0; i < bf->num_hashes; i++) {
+        one_hash = bloom_hash_value(hash_stream, width);
+        hash_stream += width;
+
+        uint64_t           word_number = one_hash >> 6;
+        uint64_t           bit_index   = one_hash & 63;
+        uint64_t           one_bit     = 1 << bit_index;
+        _Atomic(uint64_t) *p           = bf->bitfield + word_number;
+        uint64_t           actual      = atomic_read(p);
+        if (!(actual & one_bit)) {
+            return false;
+        }
+    }
+
+    return true;
+}

--- a/src/hatrack/hash/hash.c
+++ b/src/hatrack/hash/hash.c
@@ -1,0 +1,78 @@
+#include "hatrack/hash.h"
+#include "hatrack/dict.h" // For the key types.
+
+hatrack_hash_t
+hatrack_hash_by_type(uint32_t               key_type,
+                     hatrack_hash_func_t    custom,
+                     hatrack_offset_info_t *offsets,
+                     void                  *key)
+{
+    hatrack_hash_t hv;
+    uint8_t       *loc_to_hash;
+
+    switch (key_type) {
+    case HATRACK_DICT_KEY_TYPE_OBJ_CUSTOM:
+        return (*custom)(key);
+
+    case HATRACK_DICT_KEY_TYPE_INT:
+        return hash_int((uint64_t)key);
+
+    case HATRACK_DICT_KEY_TYPE_REAL:
+        return hash_double(*(double *)key);
+
+    case HATRACK_DICT_KEY_TYPE_CSTR:
+        return hash_cstr((char *)key);
+
+    case HATRACK_DICT_KEY_TYPE_PTR:
+        return hash_pointer(key);
+
+    default:
+        break;
+    }
+
+    if (!key) {
+        return hash_pointer(key);
+    }
+
+    if (offsets->cache_offset != (int32_t)HATRACK_DICT_NO_CACHE) {
+        hv = *(hatrack_hash_t *)(((uint8_t *)key) + offsets->cache_offset);
+
+        return hv;
+    }
+
+    loc_to_hash = (uint8_t *)key;
+    loc_to_hash += offsets->hash_offset;
+
+    switch (key_type) {
+    case HATRACK_DICT_KEY_TYPE_OBJ_INT:
+        hv = hash_int((uint64_t)loc_to_hash);
+        break;
+    case HATRACK_DICT_KEY_TYPE_OBJ_REAL:
+        hv = hash_double(*(double *)loc_to_hash);
+        break;
+    case HATRACK_DICT_KEY_TYPE_OBJ_CSTR:
+        if (!loc_to_hash) {
+            abort();
+        }
+        char *val = *(char **)loc_to_hash;
+
+        if (val) {
+            hv = hash_cstr(*(char **)loc_to_hash);
+        }
+        else {
+            hv = hash_cstr("\0");
+        }
+        break;
+    case HATRACK_DICT_KEY_TYPE_OBJ_PTR:
+        hv = hash_pointer(loc_to_hash);
+        break;
+    default:
+        hatrack_panic("invalid key type in hatrack_dict_get_hash_value");
+    }
+
+    if (offsets->cache_offset != (int32_t)HATRACK_DICT_NO_CACHE) {
+        *(hatrack_hash_t *)(((uint8_t *)key) + offsets->cache_offset) = hv;
+    }
+
+    return hv;
+}


### PR DESCRIPTION
Added lock-free bloom filters to hatrack, including making them an optional add-on to the more generic hatrack_dict API. Also, wrapped them in a n00b C object type, and made them available through the n00b dict API.

- [ ] Finish migrating some math stuff from n00b into hatrack (b/c hatrack now uses it)
- [ ] Test