### PR TITLE
feat: additional digraph for format delimiters

### DIFF
--- a/include/io/stream_cb.h
+++ b/include/io/stream_cb.h
@@ -16,7 +16,7 @@ extern n00b_stream_t *_n00b_new_callback_stream(n00b_stream_cb_t,
 static inline n00b_stream_t *
 n00b_name_cb_hack(n00b_stream_t *stream, char *s)
 {
-    stream->name = n00b_cformat("Callback: [|#|]", n00b_cstring(s));
+    stream->name = n00b_cformat("Callback: «#»", n00b_cstring(s));
     return stream;
 }
 

--- a/src/c-demos/iodemo.c
+++ b/src/c-demos/iodemo.c
@@ -40,7 +40,7 @@ input_callback(n00b_buf_t *b, void *capture)
         n00b_write(n00b_stderr(), n00b_cached_newline());
         break;
     default:
-        n00b_eprintf("[|em2|]*[|#|]*", b);
+        n00b_eprintf("«em2»*«#»*", b);
         break;
     }
 
@@ -52,7 +52,7 @@ sock_close(n00b_stream_t *stream, void *rcv)
 {
     n00b_flush(rcv);
     n00b_queue(n00b_stdout(),
-               n00b_crich("[|red|]Lost connection."));
+               n00b_crich("«red»Lost connection."));
     return NULL;
 }
 
@@ -66,7 +66,7 @@ sock_rcv(n00b_buf_t *b, void *ignore)
 void *
 demo_accept(n00b_stream_t *stream, void *ignore)
 {
-    n00b_printf("[|h6|]Got connection.");
+    n00b_printf("«h6»Got connection.");
     n00b_stream_t *rcv = n00b_new_callback_stream(sock_rcv,
                                                   NULL,
                                                   n00b_filter_hexdump(0x00));
@@ -87,9 +87,9 @@ void
 signal_demo2(int signal, siginfo_t *info, void *user_param)
 {
     n00b_printf(
-        "[|red|]Received SIGHUP:[|/|] "
-        "pid = [|#|], uid = [|#|], "
-        "addr = [|#:p|]",
+        "«red»Received SIGHUP:«/» "
+        "pid = «#», uid = «#», "
+        "addr = «#:p»",
         (int64_t)info->si_pid,
         (int64_t)info->si_uid,
         info->si_addr);
@@ -99,11 +99,11 @@ void
 print_eating_newline()
 {
     n00b_string_t *rich = n00b_cformat(
-        "[|b|]b[|/b|][|i|]i[|/|][|em3|]em3[|/em3|][|i|]i[|/i|]\n"
-        "[|em|]one [|em2|]two[|/em2|] [|em3|]three[|/em3|] one[|/|]\n"
-        "[|b|]b [|i|]&i[|/i|] [|u|]&u[|/u|] [|i|]&i[|/i|] b[|/b|]\n"
-        "[|b|][|i|]b&i [|u|]&u[|/|]\n"
-        "[|b|]b[|/b|][|i|]i[|/|][|em3|]em3[|/em3|][|em2|]em2[|/em2|][|/|][|i|]i[|/i|] [|em|]em[|/em|][|em2|]em2[|/|] [|b|]b [|i|]&i[|/i|] b[|/b|] [|b|][|i|]b&i[|/|] [|em3|]em3[|/em|][|em4|]em4[|/|]\n");
+        "«b»b«/b»«i»i«/»«em3»em3«/em3»«i»i«/i»\n"
+        "«em»one «em2»two«/em2» «em3»three«/em3» one«/»\n"
+        "«b»b «i»&i«/i» «u»&u«/u» «i»&i«/i» b«/b»\n"
+        "«b»«i»b&i «u»&u«/»\n"
+        "«b»b«/b»«i»i«/»«em3»em3«/em3»«em2»em2«/em2»«/»«i»i«/i» «em»em«/em»«em2»em2«/» «b»b «i»&i«/i» b«/b» «b»«i»b&i«/» «em3»em3«/em»«em4»em4«/»\n");
     n00b_print(rich);
 
     return;
@@ -121,8 +121,8 @@ main(void)
 
     // eprintf() and printf() use the stream API (n00b_printf() takes
     // an optional stream parameter.
-    n00b_eprintf("[|red|]Welcome to the IO demo[|/|]");
-    n00b_eprintf("[|p|]");
+    n00b_eprintf("«red»Welcome to the IO demo«/»");
+    n00b_eprintf("«p»");
 
     // The process API uses the stream API extensively:
     // 1) For routing data between parent and child.
@@ -164,7 +164,7 @@ main(void)
 
     // The debug system uses the stream system, with logic to use a
     // local debug server, or fail over to stderr, when not available.
-    n00b_debugf("test", "Address: [|#|]", addr);
+    n00b_debugf("test", "Address: «#»", addr);
 
     n00b_stream_t *log = n00b_stream_open_file(n00b_cstring("/tmp/testlog"),
                                                n00b_kargs_obj(
@@ -186,10 +186,10 @@ main(void)
     for (int i = 0; i < 120; i++) {
         n00b_sleep_ms(1000);
         if (!(i % 15)) {
-            n00b_string_t *s = n00b_cformat("[|em1|]tick...");
+            n00b_string_t *s = n00b_cformat("«em1»tick...");
             n00b_debug("test", s);
         }
     }
-    n00b_eprintf("[|em4|]Boom!");
+    n00b_eprintf("«em4»Boom!");
     n00b_exit(0);
 }

--- a/src/cmd/play.nc
+++ b/src/cmd/play.nc
@@ -9,11 +9,11 @@ n00b_play_capture(n00b_cmdline_ctx *ctx)
     n00b_stream_t *stream = NULL;
 
     if (ext == n00b_cached_empty_string()) {
-        arg = n00b_cformat("[|#|].cap10", arg);
+        arg = n00b_cformat("«#».cap10", arg);
     }
     else {
         if (!n00b_string_eq(ext, n00b_cstring(".cap10"))) {
-            n00b_eprintf("Capture file must have the [|em|].cap10[|/|] extension.");
+            n00b_eprintf("Capture file must have the «em».cap10«/» extension.");
             ctx->exit_code = -1;
             return;
         }
@@ -21,12 +21,12 @@ n00b_play_capture(n00b_cmdline_ctx *ctx)
     arg = n00b_resolve_path(arg);
 
     if (!n00b_path_exists(arg)) {
-        n00b_eprintf("Capture file [|em|][|#|][|/|] not found.", arg);
+        n00b_eprintf("Capture file «em»«#»«/» not found.", arg);
         ctx->exit_code = -1;
         return;
     }
     if (!n00b_path_is_file(arg)) {
-        n00b_eprintf("Capture file [|em|][|#|][|/|] is not a regular file.", arg);
+        n00b_eprintf("Capture file «em»«#»«/» is not a regular file.", arg);
         ctx->exit_code = -1;
         return;
     }
@@ -40,7 +40,7 @@ n00b_play_capture(n00b_cmdline_ctx *ctx)
     N00B_EXCEPT
     {
         n00b_exception_t *exc = N00B_X_CUR();
-        n00b_eprintf("[|red|]Error:[|/|] [|#|]", exc->msg);
+        n00b_eprintf("«red»Error:«/» «#»", exc->msg);
         fail = true;
     }
     N00B_TRY_END;

--- a/src/cmd/record.nc
+++ b/src/cmd/record.nc
@@ -52,7 +52,7 @@ n00b_record_testcase(n00b_cmdline_ctx *ctx)
     if (!n00b_path_is_directory(work_dir)) {
         if (mkdir(work_dir->data, 00744)) {
             n00b_eprintf(
-                "Could not create the directory [|em|][|#|][|/|] to save "
+                "Could not create the directory «em»«#»«/» to save "
                 "the test file.",
                 work_dir);
             ctx->exit_code = -1;
@@ -65,8 +65,8 @@ n00b_record_testcase(n00b_cmdline_ctx *ctx)
     if (n00b_string_codepoint_len(s)) {
         if (!n00b_string_eq(s, n00b_cstring(".cap10"))
             && !n00b_string_eq(s, n00b_cstring(".test"))) {
-            n00b_eprintf("Bad file extension: [|em|][|#|][|/|]", s);
-            n00b_eprintf("Must be [|i|].test .cap10,[|/|] or omitted");
+            n00b_eprintf("Bad file extension: «em»«#»«/»", s);
+            n00b_eprintf("Must be «i».test .cap10,«/» or omitted");
             ctx->exit_code = -1;
             return;
         }
@@ -76,12 +76,12 @@ n00b_record_testcase(n00b_cmdline_ctx *ctx)
     n00b_string_t *check_path;
 
     passed_path = n00b_path_simple_join(work_dir, case_name);
-    check_path  = n00b_cformat("[|#|].cap10", passed_path);
+    check_path  = n00b_cformat("«#».cap10", passed_path);
 
     if (n00b_path_exists(check_path)) {
         n00b_eprintf(
-            "Capture file for [|em|][|#|]/[|#|][|/|] already exists "
-            " at [|#|]",
+            "Capture file for «em»«#»/«#»«/» already exists "
+            " at «#»",
             group,
             case_name,
             check_path);
@@ -89,12 +89,12 @@ n00b_record_testcase(n00b_cmdline_ctx *ctx)
         return;
     }
 
-    check_path = n00b_cformat("[|#|].test", passed_path);
+    check_path = n00b_cformat("«#».test", passed_path);
 
     if (n00b_path_exists(check_path)) {
         n00b_eprintf(
-            "Capture file for [|em|][|#|]/[|#|][|/|] already exists "
-            " at [|#|]",
+            "Capture file for «em»«#»/«#»«/» already exists "
+            " at «#»",
             group,
             case_name,
             check_path);
@@ -103,16 +103,16 @@ n00b_record_testcase(n00b_cmdline_ctx *ctx)
     }
 
     n00b_set_current_directory(work_dir);
-    n00b_eprintf("[|em4|]Recording interactive shell.");
+    n00b_eprintf("«em4»Recording interactive shell.");
     if (n00b_cmd_verbose(ctx)) {
-        n00b_eprintf("Path is:[|em2|][|#|]", passed_path);
+        n00b_eprintf("Path is:«em2»«#»", passed_path);
     }
 
     n00b_testgen_record(passed_path,
                         true,
                         n00b_cmd_ansi(ctx),
                         n00b_cmd_merge(ctx));
-    n00b_eprintf("[|em4|]Recording complete.");
-    n00b_eprintf("[|em4|]Test script saved to: [|#|].", check_path);
+    n00b_eprintf("«em4»Recording complete.");
+    n00b_eprintf("«em4»Test script saved to: «#».", check_path);
     n00b_set_current_directory(pwd);
 }

--- a/src/cmd/setup.nc
+++ b/src/cmd/setup.nc
@@ -26,7 +26,7 @@ const char *n00b_cmd_doc =
 static void
 exit_gracefully(int64_t signal, void *, void *aux)
 {
-    n00b_eprintf("[|em|]Shutting down[|/|] due to signal: [|em|][|#|]",
+    n00b_eprintf("«em»Shutting down«/» due to signal: «em»«#»",
                  n00b_get_signal_name(signal));
     n00b_exit(-1);
 }

--- a/src/cmd/test.nc
+++ b/src/cmd/test.nc
@@ -17,7 +17,7 @@ n00b_run_tests(n00b_cmdline_ctx *ctx)
     ctx->exit_code = n00b_testgen_run_tests(tctx);
 
     if (ctx->exit_code) {
-        n00b_eprintf("\n[|red|]FAILED[|/|] [|#|] tests.", (int64_t)ctx->exit_code);
+        n00b_eprintf("\n«red»FAILED«/» «#» tests.", (int64_t)ctx->exit_code);
     }
 }
 
@@ -27,7 +27,7 @@ n00b_show_tests(n00b_cmdline_ctx *ctx)
     n00b_testing_ctx *tctx = n00b_testgen_setup(args : ctx->args);
 
     n00b_eprintf(
-        "[|em|][|#|][|/|] groups in use, [|em|][|#|][|/|] tests.",
+        "«em»«#»«/» groups in use, «em»«#»«/» tests.",
         tctx->groups_in_use,
         tctx->tests_in_test_dir);
 
@@ -44,14 +44,14 @@ n00b_show_tests(n00b_cmdline_ctx *ctx)
         int m = n00b_list_len(g->tests);
         for (int j = 0; j < m; j++) {
             n00b_test_t *tc = n00b_list_get(g->tests, j, NULL);
-            n00b_table_add_cell(tbl, n00b_cformat("[|#|]", tc->id + 1));
+            n00b_table_add_cell(tbl, n00b_cformat("«#»", tc->id + 1));
             n00b_table_add_cell(tbl, tc->name);
-            n00b_table_add_cell(tbl, n00b_cformat("[|#|]", tc->timeout_sec));
+            n00b_table_add_cell(tbl, n00b_cformat("«#»", tc->timeout_sec));
             n00b_table_add_cell(tbl,
-                                n00b_cformat("[|#|]",
+                                n00b_cformat("«#»",
                                              n00b_list_len(tc->commands)));
         }
-        n00b_eprintf("[|em3|]Group:[|/|] [|em6|][|#|][|/|] ", g->name);
+        n00b_eprintf("«em3»Group:«/» «em6»«#»«/» ", g->name);
         n00b_eprint(tbl);
     }
 }

--- a/src/compiler/errors.nc
+++ b/src/compiler/errors.nc
@@ -565,7 +565,7 @@ static error_info_t error_info[] = {
     [n00b_err_unk_primitive_type] = {
         n00b_err_unk_primitive_type,
         "unk_primitive_type",
-        "Type name [|em|][|#|][|/|] is not a known primitive type.",
+        "Type name «em»«#»«/» is not a known primitive type.",
         true,
     },
     [n00b_err_unk_param_type] = {

--- a/src/debug/api.nc
+++ b/src/debug/api.nc
@@ -65,14 +65,14 @@ n00b_debug_log_dump(void)
 #include "util/nowarn.h"
     cprintf("Dumping debug state to directory %s for pid %d\n", td, pid);
 #include "util/nowarn_pop.h"
-    n00b_string_t *f1 = n00b_cformat("[|#|]/locks.[|#|].log", td, pid);
+    n00b_string_t *f1 = n00b_cformat("«#»/locks.«#».log", td, pid);
     n00b_debug_all_locks(f1->data);
-    n00b_string_t *f2 = n00b_cformat("[|#|]/mem.[|#|].log", td, pid);
+    n00b_string_t *f2 = n00b_cformat("«#»/mem.«#».log", td, pid);
     n00b_mdebug_file(f2->data);
-    n00b_string_t *f3 = n00b_cformat("[|#|]/streams.[|#|].log", td, pid);
+    n00b_string_t *f3 = n00b_cformat("«#»/streams.«#».log", td, pid);
     n00b_log_streams_to_file(f3->data);
 #if defined(N00B_BACKTRACE_SUPPORTED)
-    n00b_string_t *f4   = n00b_cformat("[|#|]/trace.[|#|].log", td, pid);
+    n00b_string_t *f4   = n00b_cformat("«#»/trace.«#».log", td, pid);
     char          *s    = n00b_backtrace_cstring();
     FILE          *file = fopen(f4->data, "w");
     fprintf(file, "%s\n", s);

--- a/src/debug/server.nc
+++ b/src/debug/server.nc
@@ -25,7 +25,7 @@ received_msg(n00b_wire_dmsg_t *msg, n00b_net_addr_t *addr)
 static void *
 sock_close(n00b_stream_t *stream, n00b_net_addr_t *addr)
 {
-    n00b_eprintf("Connection from [|em1|][|#|] [|em3|]CLOSED[|/|][|p|]", addr);
+    n00b_eprintf("Connection from «em1»«#» «em3»CLOSED«/»«p»", addr);
     n00b_list_remove_item(active_connections, stream);
 
     return NULL;
@@ -52,7 +52,7 @@ accept_debug(n00b_stream_t *stream, void *ignore)
     n00b_stream_subscribe_close(stream, close_cb);
     n00b_list_append(active_connections, stream);
 
-    n00b_eprintf("Received connection from [|em1|][|#|]", addr);
+    n00b_eprintf("Received connection from «em1»«#»", addr);
 
     return NULL;
 }

--- a/src/debug/streams.nc
+++ b/src/debug/streams.nc
@@ -102,17 +102,17 @@ repr_perms(n00b_stream_t *stream)
             case 0:
                 break;
             case 1:
-                pstr = n00b_cformat("[|#|]!r", pstr);
+                pstr = n00b_cformat("«#»!r", pstr);
                 break;
             case 2:
-                pstr = n00b_cformat("[|#|]!w", pstr);
+                pstr = n00b_cformat("«#»!w", pstr);
                 break;
             default:
-                pstr = n00b_cformat("[|#|]!rw", pstr);
+                pstr = n00b_cformat("«#»!rw", pstr);
                 break;
             }
 
-            return n00b_cformat("[|#|] ([|#|])",
+            return n00b_cformat("«#» («#»)",
                                 s,
                                 pstr);
         }
@@ -149,7 +149,7 @@ prep_read_subs(n00b_stream_t *stream)
             // the data structure.
             n00b_observer_t *item   = n00b_list_get(r, i, NULL);
             n00b_stream_t   *target = (void *)item->subscriber;
-            n00b_list_append(items, n00b_cformat("[|#:x|]", target->stream_id));
+            n00b_list_append(items, n00b_cformat("«#:x»", target->stream_id));
         }
     }
 
@@ -157,7 +157,7 @@ prep_read_subs(n00b_stream_t *stream)
         for (int i = 0; i < n00b_list_len(raw); i++) {
             n00b_observer_t *item   = n00b_list_get(raw, i, NULL);
             n00b_stream_t   *target = (void *)item->subscriber;
-            n00b_list_append(items, n00b_cformat("[|#:x|] (raw)", target->stream_id));
+            n00b_list_append(items, n00b_cformat("«#:x» (raw)", target->stream_id));
         }
     }
 
@@ -189,7 +189,7 @@ prep_filters(n00b_stream_t *stream)
             }
         }
 
-        n00b_list_append(l, n00b_cformat("[|#|] ([|#|])", f->impl->name, mode));
+        n00b_list_append(l, n00b_cformat("«#» («#»)", f->impl->name, mode));
         f = f->next_write_step;
     }
 
@@ -223,7 +223,7 @@ prep_write_subs(n00b_stream_t *stream)
             n00b_observer_t *item   = n00b_list_get(q, i, NULL);
             n00b_stream_t   *target = (void *)item->subscriber;
             n00b_list_append(items,
-                             n00b_cformat("[|#:x|] (q)",
+                             n00b_cformat("«#:x» (q)",
                                           target->stream_id));
         }
     }
@@ -236,7 +236,7 @@ prep_write_subs(n00b_stream_t *stream)
             }
             n00b_stream_t *target = (void *)item->subscriber;
             n00b_list_append(items,
-                             n00b_cformat("[|#:x|] (deliver)",
+                             n00b_cformat("«#:x» (deliver)",
                                           target->stream_id));
         }
     }
@@ -251,14 +251,14 @@ prep_one_stream(n00b_stream_t *stream)
 {
     n00b_list_t *row = n00b_list(n00b_type_string());
     n00b_private_list_append(row,
-                             n00b_cformat("[|#:x|]",
+                             n00b_cformat("«#:x»",
                                           (int64_t)stream->stream_id));
 
     n00b_string_t *name     = n00b_to_string(stream);
     n00b_string_t *fd_extra = n00b_get_fd_repr(stream);
 
     if (fd_extra) {
-        name = n00b_cformat("[|#|]: [|#|]", name, fd_extra);
+        name = n00b_cformat("«#»: «#»", name, fd_extra);
     }
 
     n00b_private_list_append(row, name);

--- a/src/debug/workflow.nc
+++ b/src/debug/workflow.nc
@@ -40,8 +40,8 @@ static n00b_buf_t *
 simple_fmt(n00b_debug_msg_t *msg)
 {
     n00b_string_t *s = n00b_cformat(
-        "[|em5|][[|#|]][|/|] @[|b|][|#|]:[|/|] [|em2|]([|#|] pid [|#|])\n"
-        "[|#|]\n[|em5|][/[|#|]]",
+        "«em5»[«#»]«/» @«b»«#»:«/» «em2»(«#» pid «#»)\n"
+        "«#»\n«em5»[/«#»]",
         msg->topic,
         msg->timestamp,
         msg->remote_address,
@@ -271,7 +271,7 @@ on_log_close(n00b_stream_t *c, void *ignored)
 static void
 rcv_server_message(n00b_stream_t *c, void *msg)
 {
-    n00b_eprintf("[|h1|]Server Message: [|#|]", msg);
+    n00b_eprintf("«h1»Server Message: «#»", msg);
 }
 
 static void

--- a/src/io/fd_debug.nc
+++ b/src/io/fd_debug.nc
@@ -23,7 +23,7 @@ n00b_dump_read_subscriptions(n00b_event_loop_t *hll)
         }
 
         n00b_string_t *cstr;
-        cstr = n00b_cformat("fd [|#|] has [|#|] read subs\n",
+        cstr = n00b_cformat("fd «#» has «#» read subs\n",
                             (int64_t)s->fd,
                             (int64_t)nr,
                             0);
@@ -31,7 +31,7 @@ n00b_dump_read_subscriptions(n00b_event_loop_t *hll)
 
         for (int j = 0; j < nr; j++) {
             n00b_fd_sub_t *sub = n00b_list_get(s->read_subs, j, NULL);
-            cstr               = n00b_cformat("Subscriber param: [|#|]\n", sub->thunk);
+            cstr               = n00b_cformat("Subscriber param: «#»\n", sub->thunk);
             printf("%s", cstr->data);
         }
     }

--- a/src/io/session_replay.nc
+++ b/src/io/session_replay.nc
@@ -293,7 +293,7 @@ n00b_session_run_replay_loop(n00b_session_t *session)
     if (!read_capture_magic(log)) {
         n00b_string_t *err;
 
-        err = n00b_cformat("Stream [|em|][|#|][|/|] is not a capture file.",
+        err = n00b_cformat("Stream «em»«#»«/» is not a capture file.",
                            n00b_stream_get_name(log));
         N00B_RAISE(err);
     }

--- a/src/io/session_states.nc
+++ b/src/io/session_states.nc
@@ -29,11 +29,11 @@ build_target_name(n00b_capture_t kind, bool regex)
     }
 
     if (info != kind) {
-        s = n00b_string_concat(s, n00b_cformat(" [|em|](bad spec)"));
+        s = n00b_string_concat(s, n00b_cformat(" «em»(bad spec)"));
     }
 
     if (!info) {
-        return n00b_string_concat(s, n00b_cformat(" [|em|]missing spec"));
+        return n00b_string_concat(s, n00b_cformat(" «em»missing spec"));
     }
 
     if (kind & N00B_CAPTURE_STDIN) {
@@ -49,7 +49,7 @@ build_target_name(n00b_capture_t kind, bool regex)
         n00b_private_list_append(parts, n00b_cstring("errors"));
     }
 
-    return n00b_cformat("[|#|] [|#|]",
+    return n00b_cformat("«#» «#»",
                         s,
                         n00b_string_join(parts, n00b_cached_comma_padded()));
 }
@@ -98,7 +98,7 @@ add_one_trigger(n00b_table_t *tbl, n00b_string_t *state_name, n00b_trigger_t *t)
     }
 
     if (t->fn) {
-        n00b_table_add_cell(tbl, n00b_cformat("callback @[|#:p|]", t->fn));
+        n00b_table_add_cell(tbl, n00b_cformat("callback @«#:p»", t->fn));
     }
     else {
         n00b_table_add_cell(tbl, n00b_cstring(" "));
@@ -135,7 +135,7 @@ n00b_session_state_repr(n00b_session_t *s)
         if (!state) {
             n00b_table_add_cell(tbl, state_name);
             n00b_table_add_cell(tbl,
-                                n00b_cstring("[|red|]Error:[|/|] no state info "
+                                n00b_cstring("«red»Error:«/» no state info "
                                              "found."),
                                 -1);
             continue;
@@ -161,7 +161,7 @@ n00b_session_state_repr(n00b_session_t *s)
 
         if (!hatrack_set_contains(memos, name)) {
             n00b_table_add_cell(tbl,
-                                n00b_cformat("[|red|]Error:[|/|] state [|#|] "
+                                n00b_cformat("«red»Error:«/» state «#» "
                                              "is defined, but unreachable.",
                                              name),
                                 -1);
@@ -170,7 +170,7 @@ n00b_session_state_repr(n00b_session_t *s)
 
 add_global:
     if (s->global_actions) {
-        n00b_table_add_cell(tbl, n00b_crich("[|em4|]Global defaults"), -1);
+        n00b_table_add_cell(tbl, n00b_crich("«em4»Global defaults"), -1);
         n                    = n00b_list_len((n00b_list_t *)s->global_actions);
         n00b_string_t *empty = n00b_cstring(" ");
 
@@ -249,7 +249,7 @@ successful_match(n00b_session_t *session,
             session->cur_state_name = trigger->next_state;
         }
         else {
-            N00B_RAISE(n00b_cformat("No such state: [|#|]",
+            N00B_RAISE(n00b_cformat("No such state: «#»",
                                     trigger->next_state));
         }
         n00b_dlog_io("session: Moving to state %s due to match.",
@@ -711,7 +711,7 @@ n00b_session_state_init(n00b_session_state_t *state, va_list args)
                                    n00b_type_session_state());
     }
     if (!hatrack_dict_add(s->user_states, n, state)) {
-        err = n00b_cformat("State name [|em|][|#|] already exists.", n);
+        err = n00b_cformat("State name «em»«#» already exists.", n);
         N00B_RAISE(err);
     }
 }

--- a/src/io/stream_buffer.nc
+++ b/src/io/stream_buffer.nc
@@ -5,7 +5,7 @@ static int
 buffer_stream_init(n00b_stream_t *stream, n00b_list_t *args)
 {
     n00b_buffer_cookie_t *c   = n00b_get_stream_cookie(stream);
-    int                    ret = (int64_t)n00b_list_pop(args);
+    int                   ret = (int64_t)n00b_list_pop(args);
 
     c->buffer = n00b_list_pop(args);
 
@@ -13,7 +13,7 @@ buffer_stream_init(n00b_stream_t *stream, n00b_list_t *args)
         N00B_CRAISE("Invalid parameters for buffer");
     }
 
-    stream->name = n00b_cformat("Buffer @[|#:p|]", c->buffer);
+    stream->name = n00b_cformat("Buffer @«#:p»", c->buffer);
 
     if (n00b_list_pop(args)) {
         c->wposition = c->buffer->byte_len;
@@ -26,8 +26,8 @@ static n00b_buf_t *
 buffer_stream_read(n00b_stream_t *stream, bool *err)
 {
     n00b_buffer_cookie_t *c   = n00b_get_stream_cookie(stream);
-    n00b_buf_t            *src = c->buffer;
-    n00b_buf_t            *result;
+    n00b_buf_t           *src = c->buffer;
+    n00b_buf_t           *result;
 
     while (true) {
         _n00b_buffer_acquire_r(src);
@@ -52,8 +52,8 @@ static void
 buffer_stream_write(n00b_stream_t *stream, void *msg, bool blocking)
 {
     n00b_buffer_cookie_t *c      = n00b_get_stream_cookie(stream);
-    n00b_buf_t            *target = c->buffer;
-    n00b_buf_t            *src    = msg;
+    n00b_buf_t           *target = c->buffer;
+    n00b_buf_t           *src    = msg;
 
     defer_on();
     n00b_buffer_acquire_w(target);
@@ -181,9 +181,9 @@ static n00b_stream_impl n00b_bufchan_impl = {
 
 n00b_stream_t *
 n00b_stream_from_buffer(n00b_buf_t  *b,
-                         int64_t      mode,
-                         n00b_list_t *filters,
-                         bool         end)
+                        int64_t      mode,
+                        n00b_list_t *filters,
+                        bool         end)
 {
     n00b_list_t *args = n00b_list(n00b_type_ref());
 

--- a/src/io/stream_callback.nc
+++ b/src/io/stream_callback.nc
@@ -8,7 +8,7 @@ callback_stream_init(n00b_stream_t *stream, n00b_list_t *args)
 
     c->params    = n00b_private_list_pop(args);
     c->cb        = n00b_private_list_pop(args);
-    stream->name = n00b_cformat("Callback @[|#:p|]", c->cb);
+    stream->name = n00b_cformat("Callback @«#:p»", c->cb);
 
     return O_RDWR;
 }

--- a/src/io/stream_exit.nc
+++ b/src/io/stream_exit.nc
@@ -31,7 +31,7 @@ exit_stream_init(n00b_stream_t *stream, n00b_list_t *args)
     n00b_exit_info_t *c = (n00b_exit_info_t *)n00b_get_stream_cookie(stream);
     c->pid              = (int64_t)n00b_private_list_pop(args);
     c->waiter           = n00b_thread_spawn((void *)launch_wait, stream);
-    stream->name        = n00b_cformat("pid(exit): [|#|]", c->pid);
+    stream->name        = n00b_cformat("pid(exit): «#»", c->pid);
 
     return O_RDONLY;
 }

--- a/src/io/stream_fd.nc
+++ b/src/io/stream_fd.nc
@@ -170,24 +170,24 @@ fd_stream_init(n00b_stream_t *stream, n00b_list_t *l)
     switch ((int64_t)n00b_list_pop(l)) {
     case FD_FILE:
         stream->name    = n00b_list_pop(l);
-        c->stream->name = n00b_cformat("fd [|#|] (file)",
+        c->stream->name = n00b_cformat("fd «#» (file)",
                                        (int64_t)c->stream->fd);
         break;
     case FD_CONNECT:
         c->addr         = n00b_list_pop(l);
         stream->name    = n00b_to_string(c->addr);
-        c->stream->name = n00b_cformat("fd [|#|] (connect)",
+        c->stream->name = n00b_cformat("fd «#» (connect)",
                                        (int64_t)c->stream->fd);
         break;
     default:
         stream->name = n00b_fd_name(c->stream);
 
         if (c->stream->socket) {
-            c->stream->name = n00b_cformat("fd [|#|] (socket)",
+            c->stream->name = n00b_cformat("fd «#» (socket)",
                                            (int64_t)c->stream->fd);
         }
         else {
-            c->stream->name = n00b_cformat("fd [|#|] (pipe)",
+            c->stream->name = n00b_cformat("fd «#» (pipe)",
                                            (int64_t)c->stream->fd);
             break;
         }

--- a/src/io/stream_listener.nc
+++ b/src/io/stream_listener.nc
@@ -65,7 +65,7 @@ listener_open(n00b_stream_t *stream, n00b_list_t *args)
     c->stream->listener = true;
 
     stream->fd_backed = true;
-    stream->name      = n00b_cformat("listen: [|#|] (fd [|#|])",
+    stream->name      = n00b_cformat("listen: «#» (fd «#»)",
                                 addr,
                                 (int64_t)sock);
 

--- a/src/io/stream_proxy.nc
+++ b/src/io/stream_proxy.nc
@@ -43,7 +43,7 @@ proxy_init(n00b_stream_t *stream, n00b_stream_t *target)
     // Probably these init functions should be refactored to give you
     // the top-level object instead.
 
-    stream->name = n00b_cformat("proxy:[|#|]", target->name);
+    stream->name = n00b_cformat("proxy:«#»", target->name);
 
     if (target->r) {
         info->read_cb = n00b_new_callback_stream(on_target_read, stream);

--- a/src/io/stream_string.nc
+++ b/src/io/stream_string.nc
@@ -5,7 +5,7 @@ static int
 string_stream_init(n00b_stream_t *stream, void *args)
 {
     n00b_string_cookie_t *c = n00b_get_stream_cookie(stream);
-    c->ix                    = 0;
+    c->ix                   = 0;
 
     if (!args) {
         c->l = n00b_list(n00b_type_string());
@@ -20,7 +20,7 @@ string_stream_init(n00b_stream_t *stream, void *args)
         }
     }
 
-    stream->name = n00b_cformat("String Stream @[|#:p|]", c);
+    stream->name = n00b_cformat("String Stream @«#:p»", c);
 
     return O_RDWR;
 }
@@ -29,7 +29,7 @@ static n00b_string_t *
 string_stream_read(n00b_stream_t *stream, bool *err)
 {
     n00b_string_cookie_t *c      = n00b_get_stream_cookie(stream);
-    n00b_string_t         *result = n00b_list_get(c->l, c->ix, NULL);
+    n00b_string_t        *result = n00b_list_get(c->l, c->ix, NULL);
 
     if (!result) {
         *err = true;
@@ -57,7 +57,7 @@ static bool
 string_stream_eof(n00b_stream_t *stream)
 {
     n00b_string_cookie_t *c = n00b_get_stream_cookie(stream);
-    bool                   result;
+    bool                  result;
 
     n00b_lock_list(c->l);
     result = n00b_list_len(c->l) == c->ix;

--- a/src/ncpp/x_keyword.c
+++ b/src/ncpp/x_keyword.c
@@ -386,13 +386,13 @@ keyword_xform(xform_t *ctx, tok_t *start)
     result = concat_static(result,
                            "            __err  = "
                            "n00b_cformat(\"Invalid keyword param: "
-                           "[|em|][|#|][|/|]\",\n         "
+                           "«em»«#»«/»\",\n         "
                            "              n00b_cstring(__ka->kw));\n"
                            "            N00B_RAISE(__err);\n"
                            "        __dupe_kw_found:\n"
                            "            __err = "
                            "n00b_cformat(\"Duplicate keyword provided: "
-                           "[=em=][=#=][=/=]\",\n        "
+                           "«em»«#»«/»\",\n        "
                            "             n00b_cstring(__ka->kw));\n"
                            "            N00B_RAISE(__err);\n"
                            "        }\n    }\n");

--- a/src/text/ansi.nc
+++ b/src/text/ansi.nc
@@ -571,14 +571,14 @@ format_control_sequence(n00b_ansi_node_t *node)
     n00b_string_t *ctrl;
 
     if (node->ctrl.ppi) {
-        hdr = n00b_cformat("private ([|#:x|])", (int64_t)node->ctrl.ppi);
+        hdr = n00b_cformat("private («#:x»)", (int64_t)node->ctrl.ppi);
     }
     else {
         hdr = n00b_cstring("ctrl");
     }
 
     if (node->ctrl.plen) {
-        params = n00b_cformat("'[|#|]'",
+        params = n00b_cformat("'«#»'",
                               n00b_utf8(node->ctrl.pstart, node->ctrl.plen));
     }
     else {
@@ -588,7 +588,7 @@ format_control_sequence(n00b_ansi_node_t *node)
     // This should get the control byte.
     ctrl = n00b_utf8(node->ctrl.istart, node->ctrl.ilen + 1);
 
-    return n00b_cformat("[|#|] [|#|]: params=[|#|]", hdr, ctrl, params);
+    return n00b_cformat("«#» «#»: params=«#»", hdr, ctrl, params);
 }
 
 static n00b_string_t *
@@ -602,7 +602,7 @@ format_control_string(n00b_ansi_node_t *node, int len)
     // 4 from the length when creating a string object.
     char *p = node->start + 2;
 
-    return n00b_cformat("ctrl str: [|#|]", n00b_bytes_to_hex(p, len - 4));
+    return n00b_cformat("ctrl str: «#»", n00b_bytes_to_hex(p, len - 4));
 }
 
 static n00b_string_t *
@@ -641,7 +641,7 @@ format_control_command(n00b_ansi_node_t *node, int len)
     }
 
     // The subtract by 4 removes the start and end sequence.
-    return n00b_cformat("ctrl cmd [|#|]: [|#|]",
+    return n00b_cformat("ctrl cmd «#»: «#»",
                         kind,
                         n00b_bytes_to_hex(p, len - 4));
 }
@@ -655,21 +655,21 @@ n00b_ansi_node_repr(n00b_ansi_node_t *node)
     switch (node->kind) {
     case N00B_ANSI_TEXT:
         tmp = n00b_utf8(node->start, len);
-        return n00b_cformat("string ([|#|] bytes): [|#|]", len, tmp);
+        return n00b_cformat("string («#» bytes): «#»", len, tmp);
     case N00B_ANSI_C0_CODE:
-        return n00b_cformat("c0: [|#:x|]", (int64_t)(*node->start));
+        return n00b_cformat("c0: «#:x»", (int64_t)(*node->start));
     case N00B_ANSI_C1_CODE:
-        return n00b_cformat("c1: [|#:x|]", (int64_t)(*node->start));
+        return n00b_cformat("c1: «#:x»", (int64_t)(*node->start));
     case N00B_ANSI_NF_SEQUENCE:
-        return n00b_cformat("nf: [|#|] bytes: [|#|]",
+        return n00b_cformat("nf: «#» bytes: «#»",
                             (int64_t)len,
                             n00b_bytes_to_hex(node->start, len));
     case N00B_ANSI_FP_SEQUENCE:
-        return n00b_cformat("fp: [|#:x|]", (int64_t)(*node->start));
+        return n00b_cformat("fp: «#:x»", (int64_t)(*node->start));
     case N00B_ANSI_FE_SEQUENCE:
-        return n00b_cformat("fe: [|#:x|]", (int64_t)(*node->start));
+        return n00b_cformat("fe: «#:x»", (int64_t)(*node->start));
     case N00B_ANSI_FS_SEQUENCE:
-        return n00b_cformat("fs: [|#:x|]", (int64_t)(*node->start));
+        return n00b_cformat("fs: «#:x»", (int64_t)(*node->start));
     case N00B_ANSI_CONTROL_SEQUENCE:
     case N00B_ANSI_PRIVATE_CONTROL:
         return format_control_sequence(node);
@@ -678,11 +678,11 @@ n00b_ansi_node_repr(n00b_ansi_node_t *node)
     case N00B_ANSI_CRL_STR_CMD:
         return format_control_command(node, len);
     case N00B_ANSI_PARTIAL:
-        return n00b_cformat("partial: [|#|] bytes: [|#|]",
+        return n00b_cformat("partial: «#» bytes: «#»",
                             (int64_t)len,
                             n00b_bytes_to_hex(node->start, len));
     case N00B_ANSI_INVALID:
-        return n00b_cformat("invalid: [|#|] bytes: [|#|]",
+        return n00b_cformat("invalid: «#» bytes: «#»",
                             (int64_t)len,
                             n00b_bytes_to_hex(node->start, len));
     default:

--- a/src/text/markdown.nc
+++ b/src/text/markdown.nc
@@ -503,7 +503,7 @@ md_node_to_table(md_table_ctx *ctx)
         ctx->str = n00b_string_style_by_tag(ctx->str, n00b_cstring("em"));
 
         if (saved_str) {
-            ctx->str  = n00b_cformat("[|#|][|#|]", saved_str, ctx->str);
+            ctx->str  = n00b_cformat("«#»«#»", saved_str, ctx->str);
             saved_str = NULL;
         }
 
@@ -513,14 +513,14 @@ md_node_to_table(md_table_ctx *ctx)
         ctx->str = n00b_string_style_by_tag(ctx->str, n00b_cstring("b"));
 
         if (saved_str) {
-            ctx->str  = n00b_cformat("[|#|][|#|]", saved_str, ctx->str);
+            ctx->str  = n00b_cformat("«#»«#»", saved_str, ctx->str);
             saved_str = NULL;
         }
         return;
     case N00B_MD_SPAN_U:
         ctx->str = n00b_string_style_by_tag(ctx->str, n00b_cstring("u"));
         if (saved_str) {
-            ctx->str  = n00b_cformat("[|#|][|#|]", saved_str, ctx->str);
+            ctx->str  = n00b_cformat("«#»«#»", saved_str, ctx->str);
             saved_str = NULL;
         }
         return;
@@ -528,7 +528,7 @@ md_node_to_table(md_table_ctx *ctx)
         ctx->str = n00b_string_style_by_tag(ctx->str,
                                             n00b_cstring("strikethrough"));
         if (saved_str) {
-            ctx->str  = n00b_cformat("[|#|][|#|]", saved_str, ctx->str);
+            ctx->str  = n00b_cformat("«#»«#»", saved_str, ctx->str);
             saved_str = NULL;
         }
         return;
@@ -536,7 +536,7 @@ md_node_to_table(md_table_ctx *ctx)
     case N00B_MD_SPAN_A_CODELINK:
 finish_span:
         if (saved_str) {
-            ctx->str  = n00b_cformat("[|#|][|#|]", saved_str, ctx->str);
+            ctx->str  = n00b_cformat("«#»«#»", saved_str, ctx->str);
             saved_str = NULL;
         }
         return;

--- a/src/text/rich.nc
+++ b/src/text/rich.nc
@@ -118,6 +118,7 @@ rich_raw_tokenize(n00b_string_t      *s,
     uint8_t         *p          = (uint8_t *)s->data;
     uint8_t         *end        = (uint8_t *)s->data + s->u8_bytes;
     n00b_codepoint_t cp;
+    n00b_codepoint_t end_start        = 0;
     int              mono_start_index = -1;
     int              bi_start_index   = -1;
 
@@ -140,7 +141,8 @@ rich_raw_tokenize(n00b_string_t      *s,
             break;
         case '[':
             lookahead(p, &cp);
-            if (cp == '|') {
+            if (cp == '=' || cp == '|') {
+                end_start = cp;
                 advance(&p, &cp, &next_i);
                 bi_start_index = next_i;
             }
@@ -154,7 +156,11 @@ rich_raw_tokenize(n00b_string_t      *s,
                 next_start       = next_i;
             }
             break;
+        case '=':
         case '|':
+            if (cp != end_start) {
+                break;
+            }
             if (bi_start_index != -1) {
                 lookahead(p, &cp);
                 if (cp == ']') {
@@ -1272,7 +1278,8 @@ final_assembly(rich_ctrl_t *info, int n)
                 n00b_text_element_t *base_style = style_stack[--style_ix];
                 if (cur_props) {
                     style = n00b_text_style_overlay(base_style, cur_props);
-                } else {
+                }
+                else {
                     style = base_style;
                 }
                 di         = &result->styling->styles[next_style];
@@ -1280,14 +1287,16 @@ final_assembly(rich_ctrl_t *info, int n)
                 di->info   = style;
                 cur_style  = style;
                 last_style = next_style++;
-            } else if (cur_props) {
+            }
+            else if (cur_props) {
                 style      = n00b_text_style_overlay(cur_style, cur_props);
                 di         = &result->styling->styles[next_style];
                 di->start  = cp_ix;
                 di->info   = style;
                 cur_style  = style;
                 last_style = next_style++;
-            } else {
+            }
+            else {
                 cur_style = empty_props();
             }
             extend = false;
@@ -1403,9 +1412,9 @@ final_assembly(rich_ctrl_t *info, int n)
             if (last_style != -1) {
                 result->styling->styles[last_style].end = cp_ix;
             }
-            style_ix = 0;
-            cur_style = empty_props();
-            cur_props = empty_props();
+            style_ix   = 0;
+            cur_style  = empty_props();
+            cur_props  = empty_props();
             di         = &result->styling->styles[next_style];
             di->start  = cp_ix;
             di->info   = style;

--- a/src/text/theme.nc
+++ b/src/text/theme.nc
@@ -911,7 +911,7 @@ n00b_lookup_style_by_tag(n00b_string_t *tag)
     }
 
     if (!result) {
-        N00B_RAISE(n00b_cformat("Invalid style: [|#|]", tag));
+        N00B_RAISE(n00b_cformat("Invalid style: «#»", tag));
     }
 
     return result;

--- a/src/util/grammar.nc
+++ b/src/util/grammar.nc
@@ -150,7 +150,7 @@ n00b_nonterm_init(n00b_nonterm_t *nonterm, va_list args)
 
     if (found) {
 bail:
-        err = n00b_cformat("Duplicate ruleset name: [|em|][|#|][/]",
+        err = n00b_cformat("Duplicate ruleset name: «em»«#»[/]",
                            nonterm->name);
         N00B_RAISE(err);
     }
@@ -356,7 +356,7 @@ n00b_group_items(n00b_grammar_t *g, n00b_list_t *pitems, int min, int max)
                                                     N00B_GC_SCAN_ALL);
 
     group->gid                = n00b_rand16();
-    n00b_string_t  *tmp_name  = n00b_cformat("$$group_nt_[|#|]", group->gid);
+    n00b_string_t  *tmp_name  = n00b_cformat("$$group_nt_«#»", group->gid);
     n00b_pitem_t   *tmp_nt_pi = n00b_pitem_nonterm_raw(g, tmp_name);
     n00b_nonterm_t *nt        = n00b_pitem_get_ruleset(g, tmp_nt_pi);
 
@@ -528,7 +528,7 @@ create_one_error_rule_set(n00b_grammar_t *g, int rule_ix)
         }
         tok_ct++;
 
-        n00b_string_t  *name   = n00b_cformat("$term-[|#0|]-[|#1|]-[|#2|]",
+        n00b_string_t  *name   = n00b_cformat("$term-«#0»-«#1»-«#2»",
                                            cur->nt->name,
                                            rule_ix,
                                            tok_ct);

--- a/src/util/path.nc
+++ b/src/util/path.nc
@@ -50,7 +50,7 @@ construct_random_name(n00b_string_t *prefix, n00b_string_t *suffix)
         if (!suffix) {
             suffix = n00b_cached_empty_string();
         }
-        random_string = n00b_cformat("[|#|][|#|][|#|]",
+        random_string = n00b_cformat("«#»«#»«#»",
                                      prefix,
                                      random_string,
                                      suffix);
@@ -786,7 +786,7 @@ n00b_rename(n00b_string_t *from, n00b_string_t *to)
             ext = n00b_string_concat(n00b_cached_period(), ext);
         }
         do {
-            to = n00b_cformat("[|#|].[|#|][|#|]", base, ++i, ext);
+            to = n00b_cformat("«#».«#»«#»", base, ++i, ext);
         } while (n00b_file_exists(to));
     }
 
@@ -859,7 +859,7 @@ _n00b_list_directory(n00b_string_t *dir, ...)
     }
 
     if (extension && extension->codepoints && extension->data[0] != '.') {
-        extension = n00b_cformat(".[|#|]", extension);
+        extension = n00b_cformat(".«#»", extension);
     }
 
     n00b_list_t *result = n00b_list(n00b_type_string());

--- a/src/util/testgen.nc
+++ b/src/util/testgen.nc
@@ -59,9 +59,9 @@ gen_inject(n00b_cap_event_t *event, n00b_stream_t *output, bool hdr)
         n00b_queue(output, INJECT_HDR);
     }
 
-    s = n00b_cformat("[|#|]\n", event->contents);
+    s = n00b_cformat("«#»\n", event->contents);
     s = n00b_string_escape(s);
-    n00b_queue(output, n00b_cformat("INJECT [|#|]\n", s));
+    n00b_queue(output, n00b_cformat("INJECT «#»\n", s));
 }
 
 static inline void
@@ -80,10 +80,10 @@ gen_expect(n00b_cap_event_t *event,
     }
 
     if (err) {
-        n00b_queue(output, n00b_cformat("ERR_EXPECT [|#|]\n", s));
+        n00b_queue(output, n00b_cformat("ERR_EXPECT «#»\n", s));
     }
     else {
-        n00b_queue(output, n00b_cformat("EXPECT [|#|]\n", s));
+        n00b_queue(output, n00b_cformat("EXPECT «#»\n", s));
     }
 }
 
@@ -109,7 +109,7 @@ gen_winch(n00b_cap_event_t *event, n00b_stream_t *output, bool hdr)
     int64_t         row = ws->ws_row;
 
     n00b_queue(output,
-               n00b_cformat("SIZE [|#|]:[|#|]\n", col, row));
+               n00b_cformat("SIZE «#»:«#»\n", col, row));
 }
 
 static inline void
@@ -122,9 +122,9 @@ gen_spawn(n00b_session_t   *session,
     n00b_date_time_t      *dt    = n00b_datetime_from_duration(start);
 
     n00b_queue(output,
-               n00b_cformat("# Ran [|#|]:[|#|]\n", info->command, info->args));
+               n00b_cformat("# Ran «#»:«#»\n", info->command, info->args));
     n00b_queue(output,
-               n00b_cformat("# @[|#|]\n", dt));
+               n00b_cformat("# @«#»\n", dt));
 }
 
 static inline void
@@ -212,7 +212,7 @@ build_testgen_script(n00b_session_t *session,
 
     n00b_close(script);
 
-    n00b_string_t *dst = n00b_cformat("[|#|].test", base_path);
+    n00b_string_t *dst = n00b_cformat("«#».test", base_path);
     n00b_rename(tname, dst);
 
     return dst;
@@ -231,11 +231,11 @@ n00b_testgen_record(n00b_string_t *test_name, bool quiet, bool ansi, bool merge)
 
     if (!n00b_string_codepoint_len(ext)) {
         ext  = n00b_cstring("cap10");
-        path = n00b_cformat("[|#|].[|#|]", base, ext);
+        path = n00b_cformat("«#».«#»", base, ext);
     }
 
     if (!quiet) {
-        n00b_eprintf("[|em4|]Beginning test shell.");
+        n00b_eprintf("«em4»Beginning test shell.");
     }
 
     // Interactive shell that gets recorded.
@@ -245,7 +245,7 @@ n00b_testgen_record(n00b_string_t *test_name, bool quiet, bool ansi, bool merge)
     n00b_session_run(session);
 
     if (!quiet) {
-        n00b_eprintf("[|em4|]Test shell exited.");
+        n00b_eprintf("«em4»Test shell exited.");
     }
     events   = n00b_session_capture_extractor(session, N00B_CAPTURE_ALL);
     filename = n00b_session_capture_filename(session);
@@ -253,7 +253,7 @@ n00b_testgen_record(n00b_string_t *test_name, bool quiet, bool ansi, bool merge)
     path = n00b_rename(filename, path);
 
     if (!quiet) {
-        n00b_eprintf("[|em2|]Capture saved to: [|i|][|#|]", path);
+        n00b_eprintf("«em2»Capture saved to: «i»«#»", path);
     }
     n00b_string_t *scr = build_testgen_script(session,
                                               events,
@@ -261,7 +261,7 @@ n00b_testgen_record(n00b_string_t *test_name, bool quiet, bool ansi, bool merge)
                                               ansi,
                                               merge);
     if (!quiet) {
-        n00b_eprintf("[|em2|]Draft script saved to: [|i|][|#|]", scr);
+        n00b_eprintf("«em2»Draft script saved to: «i»«#»", scr);
     }
 }
 
@@ -391,7 +391,7 @@ static bool
 n00b_parse_test_file(n00b_test_t *test)
 {
     n00b_string_t *base     = test->path;
-    n00b_string_t *full     = n00b_cformat("[|#|].test", base);
+    n00b_string_t *full     = n00b_cformat("«#».test", base);
     n00b_string_t *contents = n00b_read_file(full);
     n00b_string_t *icmd     = n00b_cstring("INJECT ");
     n00b_string_t *x1cmd    = n00b_cstring("EXPECT ");
@@ -408,8 +408,8 @@ n00b_parse_test_file(n00b_test_t *test)
 
     if (!contents) {
         n00b_eprintf(
-            "[|red|]Error:[|/|] Couldn't load test file: "
-            "[|em|][|#|]",
+            "«red»Error:«/» Couldn't load test file: "
+            "«em»«#»",
             full);
         return false;
     }
@@ -476,8 +476,8 @@ n00b_parse_test_file(n00b_test_t *test)
         }
 
         n00b_eprintf(
-            "[|red|]Error:[|/|] "
-            "Invalid command in test file: [|em|][|#|]:[|#|]",
+            "«red»Error:«/» "
+            "Invalid command in test file: «em»«#»:«#»",
             full,
             (i + 1));
         return false;
@@ -515,7 +515,7 @@ n00b_testgen_load_test_file(n00b_string_t *s, int id)
 static inline n00b_string_t *
 new_state(n00b_session_t *s, int64_t n)
 {
-    n00b_string_t *name = n00b_cformat("state #[|#|]", n);
+    n00b_string_t *name = n00b_cformat("state #«#»", n);
     n00b_new(n00b_type_session_state(), s, name);
 
     return name;
@@ -803,9 +803,9 @@ n00b_testgen_load_one_group(n00b_testing_ctx *ctx,
     if (!n) {
         if (ctx->verbose) {
             n00b_eprintf(
-                "[|yellow|]Warning:[|/|] Directory [|em|][|#|][|/|] "
+                "«yellow»Warning:«/» Directory «em»«#»«/» "
                 "contains no test files. Test files must use the "
-                "file extension [|i|].test[|/|].",
+                "file extension «i».test«/».",
                 group->path);
         }
         return;
@@ -831,7 +831,7 @@ n00b_testgen_load_one_group(n00b_testing_ctx *ctx,
     if (n == bad_cases) {
         if (ctx->verbose) {
             n00b_eprintf(
-                "[|yellow|]Warning:[|/|] Directory [|em|][|#|][|/|] "
+                "«yellow»Warning:«/» Directory «em»«#»«/» "
                 "contains no VALID test files.");
         }
         return;
@@ -848,13 +848,13 @@ n00b_testgen_load_all_groups(n00b_testing_ctx *ctx)
 
     if (!n00b_path_is_directory(ctx->test_root)) {
         if (ctx->supplied_tdir) {
-            n00b_eprintf("Could not open test directory: [|em|][|#|][|/|].",
+            n00b_eprintf("Could not open test directory: «em»«#»«/».",
                          ctx->test_root);
         }
         else {
             n00b_eprintf(
-                "Could not find a [|em|]tests[|/|] directory under "
-                "$N00B_ROOT ([|em|][|#|][|/|]",
+                "Could not find a «em»tests«/» directory under "
+                "$N00B_ROOT («em»«#»«/»",
                 n00b_n00b_root());
         }
         n00b_exit(-1);
@@ -872,7 +872,7 @@ n00b_testgen_load_all_groups(n00b_testing_ctx *ctx)
 
     if (!n) {
         n00b_eprintf(
-            "[|red|]Error: [|/|]"
+            "«red»Error: «/»"
             "Currently, tests must be structured inside directories "
             "that group test cases. All 'dot files' (files or directories "
             "starting with a period) get ignored.");
@@ -917,8 +917,8 @@ enable_specific_group_test(n00b_test_group_t *g, n00b_string_t *tname)
     }
 
     n00b_eprintf(
-        "[|red|]Error: [|/|] No test named [|em|][|#|][|/|] "
-        "found in group [|em|][|#|][|/|]",
+        "«red»Error: «/» No test named «em»«#»«/» "
+        "found in group «em»«#»«/»",
         tname,
         g->name);
 }
@@ -966,7 +966,7 @@ start_looking:
     }
 
     n00b_eprintf(
-        "[|red|]Error:[|/|] Can't find a test group named [|em|][|#|][|/|]",
+        "«red»Error:«/» Can't find a test group named «em»«#»«/»",
         group);
 
     return;
@@ -1192,11 +1192,11 @@ create_matrix(n00b_testing_ctx *ctx)
 				      columns: 5,
 				      column_widths: ci);
 
-    n00b_table_add_cell(result, n00b_crich("[|head|]Action"));
-    n00b_table_add_cell(result, n00b_crich("[|head|]Number"));
-    n00b_table_add_cell(result, n00b_crich("[|head|]Group"));
-    n00b_table_add_cell(result, n00b_crich("[|head|]Test"));
-    n00b_table_add_cell(result, n00b_crich("[|head|]Test Result"));
+    n00b_table_add_cell(result, n00b_crich("«head»Action"));
+    n00b_table_add_cell(result, n00b_crich("«head»Number"));
+    n00b_table_add_cell(result, n00b_crich("«head»Group"));
+    n00b_table_add_cell(result, n00b_crich("«head»Test"));
+    n00b_table_add_cell(result, n00b_crich("«head»Test Result"));
 
     return result;
 }
@@ -1231,8 +1231,8 @@ n00b_testgen_run_tests(n00b_testing_ctx *ctx)
 
         if (!quiet) {
             tmp = n00b_cformat(
-                "[|h4|]Entering group:[|h1|] [|#|] "
-                "([|#|]/[|#|] enabled) [|h4|] ",
+                "«h4»Entering group:«h1» «#» "
+                "(«#»/«#» enabled) «h4» ",
                 g->name,
                 g->num_enabled,
                 m);
@@ -1246,7 +1246,7 @@ n00b_testgen_run_tests(n00b_testing_ctx *ctx)
             n00b_test_t   *tc      = n00b_list_get(g->tests, j, NULL);
             if (!tc->enabled) {
                 if (!quiet) {
-                    n00b_table_add_cell(t, n00b_crich("[|h6|]Skip"));
+                    n00b_table_add_cell(t, n00b_crich("«h6»Skip"));
                     n00b_table_add_cell(t, testnum);
                     n00b_table_add_cell(t, g->name);
                     n00b_table_add_cell(t, tc->name);
@@ -1259,7 +1259,7 @@ n00b_testgen_run_tests(n00b_testing_ctx *ctx)
             tc->pass  = false; // Just incase we do multiple runs.
 
             if (!quiet) {
-                n00b_table_add_cell(t, n00b_crich("[|h5|]Run"));
+                n00b_table_add_cell(t, n00b_crich("«h5»Run"));
                 n00b_table_add_cell(t, testnum);
                 n00b_table_add_cell(t, g->name);
                 n00b_table_add_cell(t, tc->name);
@@ -1270,20 +1270,20 @@ n00b_testgen_run_tests(n00b_testing_ctx *ctx)
 
             if (!quiet) {
                 fprintf(stderr, "\r");
-                n00b_table_add_cell(t, n00b_crich("[|h6|]Done"));
+                n00b_table_add_cell(t, n00b_crich("«h6»Done"));
                 n00b_table_add_cell(t, testnum);
                 n00b_table_add_cell(t, g->name);
                 n00b_table_add_cell(t, tc->name);
 
                 if (tc->pass) {
-                    n00b_table_add_cell(t, n00b_crich("[|green|]PASSED  "));
+                    n00b_table_add_cell(t, n00b_crich("«green»PASSED  "));
                 }
                 else {
                     if (tc->got_timeout) {
-                        n00b_table_add_cell(t, n00b_crich("[|red|]TIMEOUT"));
+                        n00b_table_add_cell(t, n00b_crich("«red»TIMEOUT"));
                     }
                     else {
-                        n00b_table_add_cell(t, n00b_crich("[|red|]FAILED "));
+                        n00b_table_add_cell(t, n00b_crich("«red»FAILED "));
                     }
                 }
 
@@ -1299,8 +1299,8 @@ n00b_testgen_run_tests(n00b_testing_ctx *ctx)
 
         if (!quiet) {
             tmp = n00b_cformat(
-                "[|h5|]Exiting group:  [|h1|][|#|] "
-                "([|#|]/[|#|] passed)",
+                "«h5»Exiting group:  «h1»«#» "
+                "(«#»/«#» passed)",
                 g->name,
                 g->passed,
                 g->num_enabled);
@@ -1314,12 +1314,12 @@ n00b_testgen_run_tests(n00b_testing_ctx *ctx)
     }
 
     if (!quiet) {
-        n00b_table_add_cell(t, n00b_cformat("[|h4|] "), -1);
+        n00b_table_add_cell(t, n00b_cformat("«h4» "), -1);
         n00b_table_end_row(t);
-        n00b_table_add_cell(t, n00b_cformat("[|h4|]SUMMARY:"), -1);
+        n00b_table_add_cell(t, n00b_cformat("«h4»SUMMARY:"), -1);
         n00b_table_end_row(t);
-        n00b_table_add_cell(t, n00b_crich("[|h1|]Passed:"), 3);
-        tmp = n00b_cformat("[|h2|][|#|]/[|#|][|/|] run tests.",
+        n00b_table_add_cell(t, n00b_crich("«h1»Passed:"), 3);
+        tmp = n00b_cformat("«h2»«#»/«#»«/» run tests.",
                            total_run - result,
                            total_run);
         n00b_table_add_cell(t, tmp, 2);
@@ -1336,7 +1336,7 @@ n00b_testgen_run_tests(n00b_testing_ctx *ctx)
         for (int64_t i = 0; i < n; i++) {
             n00b_test_t   *tc = n00b_list_pop(fails);
             n00b_string_t *tn = n00b_to_string((void *)(i + 1));
-            n00b_table_add_cell(t, n00b_crich("[|h6|]Failure"));
+            n00b_table_add_cell(t, n00b_crich("«h6»Failure"));
             n00b_table_add_cell(t, tn);
             n00b_table_add_cell(t, tc->group);
             n00b_table_add_cell(t, tc->name, 2);
@@ -1351,7 +1351,7 @@ n00b_testgen_run_tests(n00b_testing_ctx *ctx)
 
             if (tc->aux_error) {
                 if (quiet) {
-                    n00b_eprintf("Test [|#|] ([|#|]/[|#|]) [|red|]FAILED.",
+                    n00b_eprintf("Test «#» («#»/«#») «red»FAILED.",
                                  tn,
                                  tc->name,
                                  tc->name);

--- a/tests/c-tests/regex.c
+++ b/tests/c-tests/regex.c
@@ -13,7 +13,7 @@ ansi_test(n00b_buf_t *b)
     int len = n00b_list_len(r);
     for (int i = 0; i < len; i++) {
         n00b_ansi_node_t *n = n00b_list_get(r, i, NULL);
-        n00b_printf("[|#|]: [|#|]", (int64_t)(i + 1), n00b_ansi_node_repr(n));
+        n00b_printf("«#»: «#»", (int64_t)(i + 1), n00b_ansi_node_repr(n));
     }
 
     //    char *p = b->data;
@@ -21,14 +21,14 @@ ansi_test(n00b_buf_t *b)
 
     n00b_printf("Okay, reassemble, stripping:\n");
     // printf("\e[?69h\e[8;40;40t");
-    n00b_printf("[|#|]\n", n00b_ansi_nodes_to_string(r, false));
+    n00b_printf("«#»\n", n00b_ansi_nodes_to_string(r, false));
     n00b_printf("Okay, reassemble, NOT stripping:\n");
 
     n00b_list_t *parts = n00b_string_split(n00b_ansi_nodes_to_string(r, true),
                                            n00b_cached_newline());
 
     for (int i = 0; i < n00b_list_len(parts); i++) {
-        n00b_printf("[|#|]", n00b_list_get(parts, i, NULL));
+        n00b_printf("«#»", n00b_list_get(parts, i, NULL));
         printf("\n");
     }
 
@@ -64,7 +64,7 @@ regex_test(n00b_buf_t *b)
             cap = n00b_cstring("<<None>>");
         }
 
-        n00b_printf("Match [|#|] ([|#|]-[|#|]): [|#|]",
+        n00b_printf("Match «#» («#»-«#»): «#»",
                     (int64_t)(i + 1),
                     m->start,
                     m->end,

--- a/tests/c-tests/word_split.c
+++ b/tests/c-tests/word_split.c
@@ -12,7 +12,7 @@ main()
     n00b_list_t *l1 = n00b_string_split_words(for_testing);
 
     for (int i = 0; i < n00b_list_len(l1); i++) {
-        n00b_printf("Word [|#:i|]: [|#|]",
+        n00b_printf("Word «#:i»: «#»",
                     (int64_t)i,
                     n00b_list_get(l1, i, NULL));
     }

--- a/tests/rich.n
+++ b/tests/rich.n
@@ -35,25 +35,25 @@ Hello, world! Here's emphasis for my table:
 ┗┅┅┅┅┅┅┅┅┅┅┻┅┅┅┅┅┅┅┅┅┻┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┅┛
 """
 
-r = "[|em2|]Hello, world!"'r
+r = "«em2»Hello, world!"'r
 
 
 n =  [["Name",           "Country",   "City"],
-      ["[|em|]John"'r,     "USA",     "NYC"],
-      ["[|em|]Brandon"'r,  "USA",     "NYC"],
-      ["[|em|]Liming"'r,   "USA",     "NYC"],
-      ["[|em|]Miroslav"'r, "USA",     "Lawn Guy Land"],
-      ["[|em|]Rich"'r,     "USA",     "Providence, RI"],
-      ["[|em|]Matt"'r,     "USA",     "Orange"],
-      ["[|em|]Mark"'r,     "UK",      "Brighton"],
-      ["[|em|]Hugo"'r,     "UK",      "Brighton"],
-      ["[|em|]James"'r,    "UK",      "Brighton"],
-      ["[|em|]Max"'r,      "UK",      "Brighton"],
-      ["[|em|]Theo"'r,     "Greece",  "Athens"],
-      ["[|em|]Thomas"'r,   "Greece",  "Athens"],
-      ["[|em|]James II"'r, "Germany", "Berlin"]]'table
+      ["«em»John"'r,     "USA",     "NYC"],
+      ["«em»Brandon"'r,  "USA",     "NYC"],
+      ["«em»Liming"'r,   "USA",     "NYC"],
+      ["«em»Miroslav"'r, "USA",     "Lawn Guy Land"],
+      ["«em»Rich"'r,     "USA",     "Providence, RI"],
+      ["«em»Matt"'r,     "USA",     "Orange"],
+      ["«em»Mark"'r,     "UK",      "Brighton"],
+      ["«em»Hugo"'r,     "UK",      "Brighton"],
+      ["«em»James"'r,    "UK",      "Brighton"],
+      ["«em»Max"'r,      "UK",      "Brighton"],
+      ["«em»Theo"'r,     "Greece",  "Athens"],
+      ["«em»Thomas"'r,   "Greece",  "Athens"],
+      ["«em»James II"'r, "Germany", "Berlin"]]'table
 
-print(r + " Here's " + "[|em|]emphasis"'r + " for my table: ")
+print(r + " Here's " + "«em»emphasis"'r + " for my table: ")
 print(n)
 
 # also if I try to put the litmod on the n, that shouldn't crash either.


### PR DESCRIPTION
This *adds* [= =] as valid digraph syntax (in addition to the current [| |] syntax).

The current syntax is a bit more aesthetic and wouldn't expect it to be a reasonable character combo in string literals (which is desirable). But [= =] is much easier to type, and almost as uncommon (its downside is that it looks too much like an ASCII smile, even though that is pretty unused in the modern world, so seems reasonable).

Would be happy to consider other options, but after trying out [| |] for quite a white, I can say I still frequently find it difficult to type (it's a combination of switching between 'shift' and the fact that ] and | are right next to each other).

Seems like having both is a reasonable compromise for the moment.

Still, I converted all current instances of [| ... |] to the unicode « » syntax, except in the testing where appropriate.